### PR TITLE
Split hooks into separate files, load with Finder

### DIFF
--- a/web/modules/custom/custom/custom.module
+++ b/web/modules/custom/custom/custom.module
@@ -7,24 +7,12 @@
 
 declare(strict_types=1);
 
-use Drupal\discoverable_entity_bundle_classes\Storage\Node\NodeStorage;
+use Symfony\Component\Finder\Finder;
 
-/**
- * Implements hook_entity_type_build().
- */
-function custom_entity_type_build(array &$entityTypes): void {
-  /** @var \Drupal\Core\Entity\EntityTypeInterface[] $entityTypes */
-  if (isset($entityTypes['node'])) {
-    $entityTypes['node']->setStorageClass(NodeStorage::class);
-  }
-}
+$finder = Finder::create()
+  ->in(__DIR__ . DIRECTORY_SEPARATOR . 'hooks')
+  ->name('/.[php|inc]$/');
 
-/**
- * Implements hook_preprocess_HOOK().
- */
-function custom_preprocess_block(array &$variables): void {
-  // Add the 'markup' class to blocks.
-  if (in_array($variables['plugin_id'], ['views_block:featured_blog_posts-block_1'])) {
-    $variables['attributes']['class'][] = 'markup';
-  }
+foreach ($finder as $file) {
+  include $file->getPathname();
 }

--- a/web/modules/custom/custom/hooks/entity_type/build.inc
+++ b/web/modules/custom/custom/hooks/entity_type/build.inc
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @file
+ * Entity type build hooks.
+ */
+
+declare(strict_types=1);
+
+use Drupal\discoverable_entity_bundle_classes\Storage\Node\NodeStorage;
+
+/**
+ * Implements hook_entity_type_build().
+ */
+function custom_entity_type_build(array &$entityTypes): void {
+  /** @var \Drupal\Core\Entity\EntityTypeInterface[] $entityTypes */
+  if (isset($entityTypes['node'])) {
+    $entityTypes['node']->setStorageClass(NodeStorage::class);
+  }
+}

--- a/web/modules/custom/custom/hooks/preprocess/block.inc
+++ b/web/modules/custom/custom/hooks/preprocess/block.inc
@@ -1,0 +1,18 @@
+<?php
+
+/**
+ * @file
+ * Block preprocess hooks.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function custom_preprocess_block(array &$variables): void {
+  // Add the 'markup' class to blocks.
+  if (in_array($variables['plugin_id'], ['views_block:featured_blog_posts-block_1'])) {
+    $variables['attributes']['class'][] = 'markup';
+  }
+}


### PR DESCRIPTION
- Move custom hooks into separate files, organised by the type of hook.
- Update `custom.module` to load each include using Symfony Finder.