### PR TITLE
Update talk date test

### DIFF
--- a/web/modules/custom/custom/tests/src/Kernel/UpdatesTalkCreatedDateTest.php
+++ b/web/modules/custom/custom/tests/src/Kernel/UpdatesTalkCreatedDateTest.php
@@ -11,7 +11,8 @@ final class UpdatesTalkCreatedDateTest extends TalksTestBase {
 
   public function testCreatingNode() {
     $eventDate = Carbon::today()->addWeek();
-    $eventDateFormat = $eventDate->format(DateTimeItemInterface::DATE_STORAGE_FORMAT);
+    $eventDateFormat = $eventDate
+      ->format(DateTimeItemInterface::DATE_STORAGE_FORMAT);
     $eventDateTimestamp = $eventDate->getTimestamp();
 
     $talk = $this->createTalk([
@@ -20,23 +21,25 @@ final class UpdatesTalkCreatedDateTest extends TalksTestBase {
       ],
     ]);
 
-    $this->assertEqual($eventDateTimestamp, $talk->get('created')
-      ->getString());
+    $this->assertEqual($eventDateTimestamp, $talk->getCreatedTime());
   }
 
   public function testUpdatingNode() {
+    $talk = $this->createTalk();
+    $originalCreatedTime = $talk->getCreatedTime();
+
     $eventDate = Carbon::today()->addWeek();
-    $eventDateFormat = $eventDate->format(DateTimeItemInterface::DATE_STORAGE_FORMAT);
+    $eventDateFormat = $eventDate
+      ->format(DateTimeItemInterface::DATE_STORAGE_FORMAT);
     $eventDateTimestamp = $eventDate->getTimestamp();
 
-    $talk = $this->createTalk([
-      'field_events' => [
-        $this->createEvent(['field_date' => $eventDateFormat]),
-      ],
-    ]);
+    $talk->addEvent(
+      $this->createEvent(['field_date' => $eventDateFormat])
+    );
+    $talk->save();
 
-    $this->assertEqual($eventDateTimestamp, $talk->get('created')
-      ->getString());
+    $this->assertNotSame($originalCreatedTime, $talk->getCreatedTime());
+    $this->assertSame($eventDateTimestamp, $talk->getCreatedTime());
   }
 
 }


### PR DESCRIPTION
Update the test for updating a talk node as it was essentially doing the
same as the test for creating a new talk node.

The test now ensures that the talk is saved before adding an event, and
that the talk created date is different to the original created date as
well as that it matches the latest event date.