### PR TITLE
GH-140: Show upcoming talks in chronological order

### DIFF
--- a/.idea/oliverdavies-uk.iml
+++ b/.idea/oliverdavies-uk.iml
@@ -4,6 +4,8 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/web/modules/custom/custom/src" isTestSource="false" packagePrefix="Drupal\custom" />
       <sourceFolder url="file://$MODULE_DIR$/web/modules/custom/custom/tests/src" isTestSource="true" packagePrefix="Drupal\Tests\custom" />
+      <sourceFolder url="file://$MODULE_DIR$/web/modules/custom/opd_talks/tests/src" isTestSource="true" packagePrefix="Drupal\Tests\opd_talks" />
+      <sourceFolder url="file://$MODULE_DIR$/web/modules/custom/opd_talks/src" isTestSource="false" packagePrefix="Drupal\opd_talks" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/asm89/stack-cors" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/behat/mink" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/behat/mink-browserkit-driver" />

--- a/.idea/php-test-framework.xml
+++ b/.idea/php-test-framework.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PhpTestFrameworkVersionCache">
+    <tools_cache>
+      <tool tool_name="PHPUnit">
+        <cache>
+          <versions>
+            <info id="Local" version="7.5.20" />
+          </versions>
+        </cache>
+      </tool>
+    </tools_cache>
+  </component>
+</project>

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -142,4 +142,9 @@
     </include_path>
   </component>
   <component name="PhpProjectSharedConfiguration" php_language_level="7.4" />
+  <component name="PhpUnit">
+    <phpunit_settings>
+      <PhpUnitSettings configuration_file_path="$PROJECT_DIR$/phpunit.xml.dist" custom_loader_path="$PROJECT_DIR$/vendor/autoload.php" phpunit_phar_path="" use_configuration_file="true" />
+    </phpunit_settings>
+  </component>
 </project>

--- a/config/default/core.extension.yml
+++ b/config/default/core.extension.yml
@@ -38,6 +38,7 @@ module:
   migrate_plus: 0
   migrate_tools: 0
   node: 0
+  opd_talks: 0
   page_cache: 0
   path: 0
   path_alias: 0

--- a/web/modules/custom/custom/tests/modules/custom_test/config/install/views.view.talks.yml
+++ b/web/modules/custom/custom/tests/modules/custom_test/config/install/views.view.talks.yml
@@ -1,4 +1,3 @@
-uuid: a545e83a-74f7-4df1-8b49-6cafd9073ca5
 langcode: en
 status: true
 dependencies:

--- a/web/modules/custom/custom/tests/src/Kernel/TalksTestBase.php
+++ b/web/modules/custom/custom/tests/src/Kernel/TalksTestBase.php
@@ -12,6 +12,8 @@ use Drupal\paragraphs\ParagraphInterface;
 
 abstract class TalksTestBase extends EntityKernelTestBase {
 
+  protected $strictConfigSchema = FALSE;
+
   /**
    * {@inheritDoc}
    */

--- a/web/modules/custom/opd_talks/opd_talks.info.yml
+++ b/web/modules/custom/opd_talks/opd_talks.info.yml
@@ -1,0 +1,5 @@
+name: Oliver Davies Talks
+description: Custom code for talks pages.
+type: module
+core_version_requirement: ^8 || ^9
+package: Custom

--- a/web/modules/custom/opd_talks/opd_talks.module
+++ b/web/modules/custom/opd_talks/opd_talks.module
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * @file
+ * Custom code for talks pages.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Implements hook_views_data_alter().
+ */
+function opd_talks_views_data_alter(array &$data): void {
+  $data['node_field_data']['event_sort'] = [
+    'title' => t('Custom event sort'),
+    'group' => t('Content'),
+    'help' => t('Sort events by past/future, then distance from now.'),
+    'sort' => [
+      'field' => 'created',
+      'id' => 'event_sort',
+    ]
+  ];
+}

--- a/web/modules/custom/opd_talks/src/Plugin/views/sort/Event.php
+++ b/web/modules/custom/opd_talks/src/Plugin/views/sort/Event.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\opd_talks\Plugin\views\sort;
+
+use Drupal\Core\Datetime\DrupalDateTime;
+use Drupal\datetime\DateTimeComputed;
+use Drupal\views\Plugin\views\sort\Date;
+use Drupal\views\Annotation\ViewsSort;
+
+/**
+ * @ViewsSort("event_sort")
+ */
+final class Event extends Date {
+
+   public function query() {
+     $this->ensureMyTable();
+
+     $currentTime = time();
+     $dateAlias = "$this->tableAlias.$this->realField";
+
+     // Is this event in the past?
+     $this->query->addOrderBy(
+       NULL,
+       sprintf("%d > %s", $currentTime, $dateAlias),
+       $this->options['order'],
+       "in_past"
+     );
+
+     // How far in the past/future is this event?
+     $this->query->addOrderBy(
+       NULL,
+       sprintf('ABS(%s - %d)', $dateAlias, $currentTime),
+       $this->options['order'],
+       "distance_from_now"
+     );
+   }
+
+}

--- a/web/modules/custom/opd_talks/tests/src/Kernel/TalksPageSortTest.php
+++ b/web/modules/custom/opd_talks/tests/src/Kernel/TalksPageSortTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\opd_talks\Kernel;
+
+use Carbon\Carbon;
+use Drupal\Tests\custom\Kernel\TalksTestBase;
+use Drupal\views\ResultRow;
+
+final class TalksPageSortTest extends TalksTestBase {
+
+  public static $modules = [
+    'views',
+    'opd_talks',
+  ];
+
+  /**
+   * @test
+   */
+  public function upcoming_talks_are_shown_first_followed_by_past_talks_and_ordered_by_distance() {
+    $this->createTalk(['created' => Carbon::parse('+4 days')->getTimestamp()]);
+    $this->createTalk(['created' => Carbon::parse('-2 days')->getTimestamp()]);
+    $this->createTalk(['created' => Carbon::parse('+1 days')->getTimestamp()]);
+    $this->createTalk(['created' => Carbon::parse('-10 days')->getTimestamp()]);
+
+    $talkIds = array_map(
+      fn(ResultRow $row) => (int) $row->_entity->id(),
+      views_get_view_result('talks')
+    );
+
+    $this->assertSame([3, 1, 2, 4], $talkIds);
+  }
+
+}


### PR DESCRIPTION
Update the ordering of the future talks on the talks page so that
upcoming talks are shown in chronological order (soonest first),
followed by past talks in reverse chronological order (most recent
first).

This still uses the `created` date for ordering, which is updated
automatically on saving the node to match the furthest future talk, but
I may want to move that into a custom node property at some point.

Fixes #140