### PR TITLE
Add ability to add links to external posts

### DIFF
--- a/config/default/core.entity_form_display.node.post.default.yml
+++ b/config/default/core.entity_form_display.node.post.default.yml
@@ -129,4 +129,5 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_external_link: true
   field_sent_to_social_media: true

--- a/config/default/core.entity_view_display.node.post.default.yml
+++ b/config/default/core.entity_view_display.node.post.default.yml
@@ -51,6 +51,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_excerpt: true
+  field_external_link: true
   field_has_tweet: true
   field_images: true
   field_series: true

--- a/config/default/core.entity_view_display.node.post.teaser.yml
+++ b/config/default/core.entity_view_display.node.post.teaser.yml
@@ -33,6 +33,7 @@ content:
     third_party_settings: {  }
 hidden:
   body: true
+  field_external_link: true
   field_has_tweet: true
   field_images: true
   field_sent_to_social_media: true

--- a/config/default/field.field.node.post.field_external_link.yml
+++ b/config/default/field.field.node.post.field_external_link.yml
@@ -1,0 +1,23 @@
+uuid: 09df4309-5909-4347-ae8a-e35f84e1930d
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_external_link
+    - node.type.post
+  module:
+    - link
+id: node.post.field_external_link
+field_name: field_external_link
+entity_type: node
+bundle: post
+label: 'External link'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  link_type: 16
+  title: 2
+field_type: link

--- a/config/default/field.storage.node.field_external_link.yml
+++ b/config/default/field.storage.node.field_external_link.yml
@@ -1,0 +1,19 @@
+uuid: 2faf15c2-a456-485c-b7bd-30ff75e4cc21
+langcode: en
+status: true
+dependencies:
+  module:
+    - link
+    - node
+id: node.field_external_link
+field_name: field_external_link
+entity_type: node
+type: link
+settings: {  }
+module: link
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/web/modules/custom/custom/hooks/node_links/alter.inc
+++ b/web/modules/custom/custom/hooks/node_links/alter.inc
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Node links alter hooks.
+ */
+
+declare(strict_types=1);
+
+use Drupal\Core\Url;
+use Drupal\node\NodeInterface;
+
+/**
+ * Implements hook_node_links_alter().
+ */
+function custom_node_links_alter(array &$links, NodeInterface $node): void {
+  if ($link = $node->getExternalLink()) {
+    $links['node']['#links']['node-readmore']['url'] = Url::fromUri($link['uri']);
+    $links['node']['#links']['node-readmore']['title'] = t('Read more<span class="visually-hidden"> about @title</span> (<span class="visually-hidden">on </span>@domain)', [
+      '@domain' => $link['title'],
+      '@title' => $node->label(),
+    ]);
+  }
+}

--- a/web/modules/custom/custom/hooks/preprocess/node.inc
+++ b/web/modules/custom/custom/hooks/preprocess/node.inc
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * @file
+ * Node preprocess functions.
+ */
+
+declare(strict_types=1);
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function custom_preprocess_node(array &$variables): void {
+  if ($link = $variables['node']->getExternalLink()) {
+    $variables['url'] = $link['uri'];
+  }
+}

--- a/web/modules/custom/custom/src/Entity/Node/Post.php
+++ b/web/modules/custom/custom/src/Entity/Node/Post.php
@@ -18,12 +18,22 @@ use Drupal\node\Entity\Node;
  */
 class Post extends Node implements ContentEntityBundleInterface {
 
+  public function getExternalLink(): ?array {
+    return ($link = $this->get('field_external_link')->get(0))
+      ? $link->getValue()
+      : NULL;
+  }
+
   public function hasBeenSentToSocialMedia(): bool {
     return (bool) $this->get('field_sent_to_social_media')->getString();
   }
 
   public function hasTweet(): bool {
     return (bool) $this->get('field_has_tweet')->getString();
+  }
+
+  public function isExternalPost(): bool {
+    return (bool) $this->getExternalLink();
   }
 
   public function toTweet(): string {

--- a/web/modules/custom/custom/src/EventSubscriber/PushBlogPostToSocialMedia.php
+++ b/web/modules/custom/custom/src/EventSubscriber/PushBlogPostToSocialMedia.php
@@ -7,7 +7,6 @@ namespace Drupal\custom\EventSubscriber;
 use Drupal\custom\Entity\Node\Post;
 use Drupal\hook_event_dispatcher\Event\Entity\BaseEntityEvent;
 use Drupal\hook_event_dispatcher\HookEventDispatcherInterface;
-use Drupal\node\NodeInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 final class PushBlogPostToSocialMedia implements EventSubscriberInterface {
@@ -28,7 +27,7 @@ final class PushBlogPostToSocialMedia implements EventSubscriberInterface {
       return;
     }
 
-    /** @var NodeInterface $entity */
+    /** @var Post $entity */
     if ($entity->bundle() != 'post') {
       return;
     }
@@ -39,6 +38,10 @@ final class PushBlogPostToSocialMedia implements EventSubscriberInterface {
 
     // If this post has already been sent to social media, do not send it again.
     if ($entity->hasBeenSentToSocialMedia()) {
+      return;
+    }
+
+    if ($entity->isExternalPost()) {
       return;
     }
 


### PR DESCRIPTION
Add the ability to add links to external blog posts within my blog feed.
This is done based on a new `field_external_link` field that allows for
adding the external link URL and the domain name as the title.

The node links are then overridden to use the external link if there is
one, so the node title and 'read more' links are changed to use the
external link.

Currently, automated tweets are not generated for external posts.

Fixes #182