### PR TITLE
Remove .git directories within contrib modules

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -31,6 +31,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 7.4
+          tools: composer:v1
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-interaction --no-suggest

--- a/.github/workflows/drupal-install.yml
+++ b/.github/workflows/drupal-install.yml
@@ -33,6 +33,7 @@ jobs:
           php-version: 7.4
           extensions: mbstring
           coverage: none
+          tools: composer:v1
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-interaction --no-suggest

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -40,6 +40,7 @@ jobs:
           php-version: 7.4
           extensions: mbstring
           coverage: none
+          tools: composer:v1
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-interaction --no-suggest

--- a/.github/workflows/static-code-analysis.yml
+++ b/.github/workflows/static-code-analysis.yml
@@ -31,6 +31,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 7.4
+          tools: composer:v1
 
       - name: Install dependencies
         run: composer install --prefer-dist --no-interaction --no-suggest

--- a/.idea/oliverdavies-uk.iml
+++ b/.idea/oliverdavies-uk.iml
@@ -130,6 +130,7 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/var-dumper" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/yaml" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/theseer/tokenizer" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/topfloor/composer-cleanup-vcs-dirs" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/twig/twig" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/typo3/phar-stream-wrapper" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/voku/portable-ascii" />

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -147,6 +147,7 @@
       <path value="$PROJECT_DIR$/vendor/laminas/laminas-diactoros" />
       <path value="$PROJECT_DIR$/vendor/laminas/laminas-escaper" />
       <path value="$PROJECT_DIR$/vendor/beberlei/assert" />
+      <path value="$PROJECT_DIR$/vendor/topfloor/composer-cleanup-vcs-dirs" />
     </include_path>
   </component>
   <component name="PhpProjectSharedConfiguration" php_language_level="7.4" />

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
         "drupal/stage_file_proxy": "^1.0",
         "drush/drush": "^9",
         "illuminate/support": "^7.10",
-        "nesbot/carbon": "^2.33"
+        "nesbot/carbon": "^2.33",
+        "topfloor/composer-cleanup-vcs-dirs": "^1.0"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dcefedfd2f7ee2173cec5928b432d12a",
+    "content-hash": "251bb73361539f16425f518ae1c2a858",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -7699,6 +7699,44 @@
                 }
             ],
             "time": "2020-05-11T07:51:54+00:00"
+        },
+        {
+            "name": "topfloor/composer-cleanup-vcs-dirs",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/TopFloorTech/composer-cleanup-vcs-dirs.git",
+                "reference": "0158853dd054321b5048108ed5532c4b5e002d1b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/TopFloorTech/composer-cleanup-vcs-dirs/zipball/0158853dd054321b5048108ed5532c4b5e002d1b",
+                "reference": "0158853dd054321b5048108ed5532c4b5e002d1b",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0.0",
+                "php": ">=5.5",
+                "symfony/finder": "*"
+            },
+            "require-dev": {
+                "composer/composer": "dev-master"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "TopFloor\\ComposerCleanupVcsDirs\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "TopFloor\\ComposerCleanupVcsDirs\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "description": "Automatically deletes .git directories in newly installed or updated dependencies.",
+            "time": "2016-10-06T04:35:51+00:00"
         },
         {
             "name": "twig/twig",


### PR DESCRIPTION
Automatically remove any `.git` directories within the project's
dependencies, such as within contrib modules like Plausible which caused
`web/modules/contrib` to keep appearing and being added to the index.