### PR TITLE
Run `composer validate` in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,9 @@ jobs:
           coverage: none
           tools: composer:v1
 
+      - name: Ensure that composer.json and composer.lock are in sync
+        run: composer validate
+
       - name: Install dependencies
         run: composer install --prefer-dist --no-interaction --no-suggest
 


### PR DESCRIPTION
This ensures that the composer.json and composer.lock files are in sync
before trying to install the site.