### PR TITLE
Fix Plausible loading for authenticated users

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -114,6 +114,9 @@
             ]
         },
         "patches": {
+            "drupal/plausible": {
+                "Return early if user is not anonymous": "tools/patches/plausible/return-if-authenticated.patch"
+            }
         }
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fe496bbcb4eef8b520c250b2c4d70d83",
+    "content-hash": "6aa7c4e54ecdea98cfca107f6be3cc9e",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -8229,12 +8229,12 @@
             "version": "1.9.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/webmozart/assert.git",
+                "url": "https://github.com/webmozarts/assert.git",
                 "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "shasum": ""
             },
@@ -8272,8 +8272,8 @@
                 "validate"
             ],
             "support": {
-                "issues": "https://github.com/webmozart/assert/issues",
-                "source": "https://github.com/webmozart/assert/tree/master"
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/1.9.1"
             },
             "time": "2020-07-08T17:02:28+00:00"
         },

--- a/tools/patches/plausible/return-if-authenticated.patch
+++ b/tools/patches/plausible/return-if-authenticated.patch
@@ -1,0 +1,20 @@
+diff --git a/plausible.module b/plausible.module
+index ce5a826..aa78dc5 100644
+--- a/plausible.module
++++ b/plausible.module
+@@ -16,9 +16,14 @@ use Drupal\plausible\Component\Render\PlausibleJavaScriptSnippet;
+ function plausible_page_attachments(array &$attachments) {
+   $account = \Drupal::currentUser();
+ 
+-  if (! (_plausible_visibility_pages() && _plausible_visibility_roles($account))) {
++  if (!_plausible_visibility_pages()) {
+     return;
+   }
++
++  if ($account->isAuthenticated()) {
++    return;
++  }
++
+   $config = \Drupal::config('plausible.settings');
+   $attachments['#attached']['html_head'][] = [
+     [


### PR DESCRIPTION
Return early within the Plausible if the user is authenticated so that
it doesn't pick up when I'm adding or editing content on the site.

Though the role is configured in the Plausible module's admin form, the
conditions in the code don't exclude it. I'll look into this further and
submit a patch upstream along with some tests.