### PR TITLE
Fix the Composer version

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -27,7 +27,7 @@ RUN apt update -yqq \
 COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
 
 WORKDIR /app
-ENV PATH="/app/bin:$PATH"
+ENV PATH="$PATH:/app/bin"
 
 COPY composer.json composer.lock /app/
 COPY assets /app/assets


### PR DESCRIPTION
Even though Composer v2 was being pulled from the Composer Docker image,
Composer v1 was still being used.

Because I've added the `/app/bin` path to `$PATH`, a version in
`/app/bin/composer` was being used. The simplest way that I can fix
this is re-ordering the variable so that the path is added after the
originals and the Composer version in `/usr/bin/composer` is used.